### PR TITLE
Extract release report

### DIFF
--- a/src/Distroessed/Program.cs
+++ b/src/Distroessed/Program.cs
@@ -1,5 +1,4 @@
 ﻿using DotnetRelease;
-using EndOfLifeDate;
 
 if (args.Length is 0 || !int.TryParse(args[0], out int majorVersion))
 {
@@ -7,131 +6,8 @@ if (args.Length is 0 || !int.TryParse(args[0], out int majorVersion))
     return;
 }
 
-string version = $"{majorVersion}.0";
-string baseDefaultURL = "https://raw.githubusercontent.com/dotnet/core/main/release-notes/";
-string baseUrl = args.Length > 1 ? args[1] : baseDefaultURL;
-bool preferWeb = baseUrl.StartsWith("https");
-HttpClient client= new();
-DateOnly threeMonthsDate = DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(3));
-string supportMatrixUrl, releaseUrl;
-SupportedOSMatrix? matrix = null;
-MajorReleaseOverview? majorRelease = null;
-ReportOverview report = new(DateTime.UtcNow, version, []);
-
-if (preferWeb)
-{
-    supportMatrixUrl = $"{baseUrl}/{version}/supported-os.json";
-    releaseUrl = $"{baseUrl}/{version}/releases.json";
-}
-else
-{
-    supportMatrixUrl = Path.Combine(baseUrl, version,"supported-os.json");
-    releaseUrl = Path.Combine(baseUrl, version,"releases.json");   
-}
-
-if (preferWeb)
-{
-    matrix = await ReleaseNotes.GetSupportedOSes(client, supportMatrixUrl);
-    majorRelease = await ReleaseNotes.GetMajorRelease(client, releaseUrl);
-}   
-else
-{
-    matrix = await ReleaseNotes.GetSupportedOSes(File.OpenRead(supportMatrixUrl));
-    majorRelease = await ReleaseNotes.GetMajorRelease(File.OpenRead(releaseUrl));
-}
-
-DateOnly initialRelease = majorRelease?.Releases.FirstOrDefault(r => r.ReleaseVersion.Equals($"{majorVersion}.0.0"))?.ReleaseDate ?? DateOnly.MaxValue;
-DateOnly eolDate = majorRelease?.EolDate ?? DateOnly.MaxValue;
-
-foreach (SupportFamily family in matrix?.Families ?? throw new Exception())
-{
-    ReportFamily reportFamily = new(family.Name, []);
-    report.Families.Add(reportFamily);
-
-    foreach (SupportDistribution distro in family.Distributions)
-    {
-        IList<SupportCycle>? cycles;
-        List<string> activeReleases = [];
-        List<string> unsupportedActiveRelease = [];
-        List<string> soonEolReleases = [];
-        List<string> supportedUnActiveReleases = [];
-        List<string> missingReleases = [];
-        
-        try
-        {
-            cycles = await EndOfLifeDate.Product.GetProduct(client, distro.Id);
-            if (cycles is null)
-            {
-                continue;
-            }
-        }
-        catch (HttpRequestException)
-        {
-            Console.WriteLine($"No data found at endoflife.date for: {distro.Id}");
-            Console.WriteLine();
-            continue;
-        }
-
-        foreach (SupportCycle cycle in cycles)
-        {
-            SupportInfo support = cycle.GetSupportInfo();
-            // dotnet statements
-            bool isSupported = distro.SupportedVersions.Contains(cycle.Cycle);
-            bool isUnsupported = distro.UnsupportedVersions?.Contains(cycle.Cycle) ?? false;
-            // EndofLife.Date statement
-            bool isActive = support.IsActive;
-            bool hasOverlappingLifecycle = initialRelease <= support.EolDate && cycle.ReleaseDate <= eolDate;
-
-            if (isActive)
-            {
-                activeReleases.Add(cycle.Cycle);
-            }
-
-            /*
-                Cases (EOLDate, dotnet):
-                1. (Active, Supported)
-                2. (Active, Unsupported)
-                3. (OverlappingLifecycle, Unlisted)
-                4. (EOL, Supported)
-                5. (Active - EolSoon, Supported)
-                // these are not covered
-                6. (Unlisted, Listed)
-                7. (EOL, Unsupported | Unlisted)
-                8. (Listed, Unlisted)
-            */
-
-            // Case 1
-            if (isActive && isSupported)
-            {
-                // nothing to do
-            }
-            // Case 2
-            else if (isActive && isUnsupported)
-            {
-                unsupportedActiveRelease.Add(cycle.Cycle);
-            }
-            // Case 3
-            else if (hasOverlappingLifecycle && !isSupported && !isUnsupported)
-            {
-                missingReleases.Add(cycle.Cycle);
-            }
-            // Case 4
-            else if (!isActive && isSupported)
-            {
-                supportedUnActiveReleases.Add(cycle.Cycle);
-            }            
-
-            if (isActive && support.EolDate < threeMonthsDate)
-            {
-                soonEolReleases.Add(cycle.Cycle);
-            }
-        }
-
-        ReportDistribution reportDistribution = new(distro.Name, activeReleases, unsupportedActiveRelease, soonEolReleases, supportedUnActiveReleases, missingReleases);
-        reportFamily.Distributions.Add(reportDistribution);
-    }
-}
-
+string? baseUrl = args.Length > 1 ? args[1] : null;
+var report = await ReleaseReportGenerator.GetReportOverviewAsync(majorVersion, baseUrl);
 var reportJson = ReleaseReport.WriteReport(report);
 
 Console.WriteLine(reportJson);

--- a/src/Distroessed/Program.cs
+++ b/src/Distroessed/Program.cs
@@ -6,29 +6,18 @@ if (args.Length is 0 || !int.TryParse(args[0], out int majorVersion))
     return;
 }
 
-string defaultBaseUrl = "https://raw.githubusercontent.com/dotnet/core/main/release-notes/";
-string baseUrl = args.Length > 1 ? args[1] : defaultBaseUrl;
+string? baseUrl = args.Length > 1 ? args[1] : null;
 
 string version = $"{majorVersion}.0";
-bool preferWeb = baseUrl.StartsWith("https");
-HttpClient client= new();
-string supportMatrixUrl, releaseUrl;
+string supportMatrixUrl = ReleaseNotes.GetUri(ReleaseNotes.SupportedOS, version, baseUrl);
+string releaseUrl = ReleaseNotes.GetUri(ReleaseNotes.Releases, version, baseUrl);
+bool preferWeb = supportMatrixUrl.StartsWith("https");
 SupportedOSMatrix? matrix = null;
 MajorReleaseOverview? majorRelease = null;
 
 if (preferWeb)
 {
-    supportMatrixUrl = $"{baseUrl}/{version}/supported-os.json";
-    releaseUrl = $"{baseUrl}/{version}/releases.json";
-}
-else
-{
-    supportMatrixUrl = Path.Combine(baseUrl, version,"supported-os.json");
-    releaseUrl = Path.Combine(baseUrl, version,"releases.json");   
-}
-
-if (preferWeb)
-{
+    HttpClient client = new();
     matrix = await ReleaseNotes.GetSupportedOSes(client, supportMatrixUrl);
     majorRelease = await ReleaseNotes.GetMajorRelease(client, releaseUrl);
 }   

--- a/src/Distroessed/Program.cs
+++ b/src/Distroessed/Program.cs
@@ -6,8 +6,39 @@ if (args.Length is 0 || !int.TryParse(args[0], out int majorVersion))
     return;
 }
 
-string? baseUrl = args.Length > 1 ? args[1] : null;
-var report = await ReleaseReportGenerator.GetReportOverviewAsync(majorVersion, baseUrl);
+string defaultBaseUrl = "https://raw.githubusercontent.com/dotnet/core/main/release-notes/";
+string baseUrl = args.Length > 1 ? args[1] : defaultBaseUrl;
+
+string version = $"{majorVersion}.0";
+bool preferWeb = baseUrl.StartsWith("https");
+HttpClient client= new();
+string supportMatrixUrl, releaseUrl;
+SupportedOSMatrix? matrix = null;
+MajorReleaseOverview? majorRelease = null;
+
+if (preferWeb)
+{
+    supportMatrixUrl = $"{baseUrl}/{version}/supported-os.json";
+    releaseUrl = $"{baseUrl}/{version}/releases.json";
+}
+else
+{
+    supportMatrixUrl = Path.Combine(baseUrl, version,"supported-os.json");
+    releaseUrl = Path.Combine(baseUrl, version,"releases.json");   
+}
+
+if (preferWeb)
+{
+    matrix = await ReleaseNotes.GetSupportedOSes(client, supportMatrixUrl);
+    majorRelease = await ReleaseNotes.GetMajorRelease(client, releaseUrl);
+}   
+else
+{
+    matrix = await ReleaseNotes.GetSupportedOSes(File.OpenRead(supportMatrixUrl));
+    majorRelease = await ReleaseNotes.GetMajorRelease(File.OpenRead(releaseUrl));
+}
+
+var report = await ReleaseReportGenerator.GetReportOverviewAsync(matrix, majorRelease);
 var reportJson = ReleaseReport.WriteReport(report);
 
 Console.WriteLine(reportJson);

--- a/src/Distroessed/distroessed.csproj
+++ b/src/Distroessed/distroessed.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\DotnetRelease\DotnetRelease.csproj" />
-    <ProjectReference Include="..\EndOfLifeDate\EndOfLifeDate.csproj" />
+    <ProjectReference Include="..\ReleaseReport\ReleaseReport.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/DotnetRelease/PatchReleaseOverviewRecords.cs
+++ b/src/DotnetRelease/PatchReleaseOverviewRecords.cs
@@ -78,6 +78,10 @@ public record RuntimeComponent(
         JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     string VSVersion,
 
+    [property: Description("The version of Visual Studio on MacOS that includes this component version."),
+        JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string VSMacVersion,
+
     [property: Description("The files that are available for this component.")]
     IList<ComponentFile> Files,
 
@@ -100,8 +104,14 @@ public record SdkComponent(
     [property: Description("The version of Visual Studio that includes this component version.")]
     string VSVersion,
 
+    [property: Description("The version of Visual Studio on MacOS that includes this component version.")]
+    string VSMacVersion,
+
     [property: Description("The minimum version of Visual Studio that supports this component version.")]
     string VSSupport,
+
+    [property: Description("The minimum version of Visual Studio on MacOS that supports this component version.")]
+    string VSMacSupport,
 
     [property: Description("The version of C# included in the component."),
         JsonPropertyName("csharp-version")]

--- a/src/DotnetRelease/ReleaseNotes.cs
+++ b/src/DotnetRelease/ReleaseNotes.cs
@@ -19,6 +19,8 @@ public class ReleaseNotes
 
     public static string Releases { get; private set; } = "releases.json";
 
+    public static string PatchRelease { get; private set; } = "release.json";
+
     public static string SupportedOS { get; private set; } = "supported-os.json";
 
     public static string PreviewDirectory { get; private set; } = "preview";
@@ -76,6 +78,14 @@ public class ReleaseNotes
         {
             return new(name, "preview", true);
         }
+    }
+
+    public static string GetUri(string fileName, string version, string? baseUri = null)
+    {
+        baseUri ??= GitHubBaseUri;
+        return baseUri.StartsWith("https")
+            ? $"{baseUri}/{version}/{fileName}"
+            : Path.Combine(baseUri, version, fileName);
     }
 }
 

--- a/src/DotnetRelease/ReleaseReportRecords.cs
+++ b/src/DotnetRelease/ReleaseReportRecords.cs
@@ -4,4 +4,4 @@ public record ReportOverview(DateTime Timestamp, string Version, IList<ReportFam
 
 public record ReportFamily(string Name, IList<ReportDistribution> Distributions);
 
-public record ReportDistribution(string Name, IList<string> ActiveReleases, IList<string> ActiveReleasesUnsupported, IList<string> ActiveReleasesEOLSoon, IList<string>  NotActiveReleasesSupported, IList<string>  ReleasesMissing);
+public record ReportDistribution(string Name, IList<string> ActiveReleases, IList<string> ActiveReleasesUnsupported, IList<string> ActiveReleasesEOLSoon, IList<string> NotActiveReleasesSupported, IList<string> NotActiveReleasesUnsupported, IList<string> ReleasesMissing);

--- a/src/DotnetRelease/SerializerContext.cs
+++ b/src/DotnetRelease/SerializerContext.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace DotnetRelease;

--- a/src/DotnetRelease/SupportedOS.cs
+++ b/src/DotnetRelease/SupportedOS.cs
@@ -1,7 +1,3 @@
-using System.Net.Http.Json;
-using System.Text.Json;
-using System.Text.Json.Serialization;
-
 namespace DotnetRelease;
 
 public class SupportedOS

--- a/src/LinuxPackagesMd/Program.cs
+++ b/src/LinuxPackagesMd/Program.cs
@@ -18,9 +18,7 @@ string packageJson = baseUrl;
 
 if (!packageJson.EndsWith(".json"))
 {
-    packageJson = preferWeb ?
-        $"{baseUrl}/{version}/os-packages.json" :
-        Path.Combine(baseUrl, version,"os-packages.json");
+    packageJson = ReleaseNotes.GetUri(ReleaseNotes.OSPackages, version, baseUrl);
 }
 
 string file = "os-packages.md";

--- a/src/MarkdownHelpers/BreakBuffer.cs
+++ b/src/MarkdownHelpers/BreakBuffer.cs
@@ -4,7 +4,7 @@ namespace MarkdownHelpers;
 
 public class BreakBuffer(StringBuilder builder, int index = 0)
 {
-    StringBuilder _builder = builder;
+    readonly StringBuilder _builder = builder;
     int _index = index;
 
     public void Append(string value)

--- a/src/MarkdownHelpers/Link.cs
+++ b/src/MarkdownHelpers/Link.cs
@@ -1,5 +1,3 @@
-using System.Collections.Specialized;
-
 namespace MarkdownHelpers;
 
 public class Link(int startingIndex = 0)

--- a/src/MarkdownHelpers/Table.cs
+++ b/src/MarkdownHelpers/Table.cs
@@ -1,15 +1,9 @@
-using System.ComponentModel.DataAnnotations.Schema;
-using System.Data.Common;
-using System.IO.Compression;
-using System.Text;
-using Microsoft.VisualBasic.FileIO;
-
 namespace MarkdownHelpers;
 
 public class Table(IWriter writer, int[] columns)
 {
     private readonly IWriter _writer = writer;
-    private int[] _columns = columns;
+    private readonly int[] _columns = columns;
     private readonly int _columnMax = columns.Length - 1;
     private int _column = 0;
     private int _realLength = 0;

--- a/src/ReleaseReport/ReleaseReport.csproj
+++ b/src/ReleaseReport/ReleaseReport.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\DotnetRelease\DotnetRelease.csproj" />
+    <ProjectReference Include="..\EndOfLifeDate\EndOfLifeDate.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/ReleaseReport/ReleaseReportGenerator.cs
+++ b/src/ReleaseReport/ReleaseReportGenerator.cs
@@ -1,0 +1,135 @@
+﻿using DotnetRelease;
+using EndOfLifeDate;
+
+public class ReleaseReportGenerator
+{
+    public static async Task<ReportOverview> GetReportOverviewAsync(int majorVersion, string? baseUrl = null)
+    {
+        baseUrl ??= "https://raw.githubusercontent.com/dotnet/core/main/release-notes/";
+
+        string version = $"{majorVersion}.0";
+        bool preferWeb = baseUrl.StartsWith("https");
+        HttpClient client= new();
+        DateOnly threeMonthsDate = DateOnly.FromDateTime(DateTime.UtcNow.AddMonths(3));
+        string supportMatrixUrl, releaseUrl;
+        SupportedOSMatrix? matrix = null;
+        MajorReleaseOverview? majorRelease = null;
+        ReportOverview report = new(DateTime.UtcNow, version, []);
+
+        if (preferWeb)
+        {
+            supportMatrixUrl = $"{baseUrl}/{version}/supported-os.json";
+            releaseUrl = $"{baseUrl}/{version}/releases.json";
+        }
+        else
+        {
+            supportMatrixUrl = Path.Combine(baseUrl, version,"supported-os.json");
+            releaseUrl = Path.Combine(baseUrl, version,"releases.json");   
+        }
+
+        if (preferWeb)
+        {
+            matrix = await ReleaseNotes.GetSupportedOSes(client, supportMatrixUrl);
+            majorRelease = await ReleaseNotes.GetMajorRelease(client, releaseUrl);
+        }   
+        else
+        {
+            matrix = await ReleaseNotes.GetSupportedOSes(File.OpenRead(supportMatrixUrl));
+            majorRelease = await ReleaseNotes.GetMajorRelease(File.OpenRead(releaseUrl));
+        }
+
+        DateOnly initialRelease = majorRelease?.Releases.FirstOrDefault(r => r.ReleaseVersion.Equals($"{majorVersion}.0.0"))?.ReleaseDate ?? DateOnly.MaxValue;
+        DateOnly eolDate = majorRelease?.EolDate ?? DateOnly.MaxValue;
+
+        foreach (SupportFamily family in matrix?.Families ?? throw new Exception())
+        {
+            ReportFamily reportFamily = new(family.Name, []);
+            report.Families.Add(reportFamily);
+
+            foreach (SupportDistribution distro in family.Distributions)
+            {
+                IList<SupportCycle>? cycles;
+                List<string> activeReleases = [];
+                List<string> unsupportedActiveRelease = [];
+                List<string> soonEolReleases = [];
+                List<string> supportedUnActiveReleases = [];
+                List<string> missingReleases = [];
+                
+                try
+                {
+                    cycles = await EndOfLifeDate.Product.GetProduct(client, distro.Id);
+                    if (cycles is null)
+                    {
+                        continue;
+                    }
+                }
+                catch (HttpRequestException)
+                {
+                    Console.WriteLine($"No data found at endoflife.date for: {distro.Id}");
+                    Console.WriteLine();
+                    continue;
+                }
+
+                foreach (SupportCycle cycle in cycles)
+                {
+                    SupportInfo support = cycle.GetSupportInfo();
+                    // dotnet statements
+                    bool isSupported = distro.SupportedVersions.Contains(cycle.Cycle);
+                    bool isUnsupported = distro.UnsupportedVersions?.Contains(cycle.Cycle) ?? false;
+                    // EndofLife.Date statement
+                    bool isActive = support.IsActive;
+                    bool hasOverlappingLifecycle = initialRelease <= support.EolDate && cycle.ReleaseDate <= eolDate;
+
+                    if (isActive)
+                    {
+                        activeReleases.Add(cycle.Cycle);
+                    }
+
+                    /*
+                        Cases (EOLDate, dotnet):
+                        1. (Active, Supported)
+                        2. (Active, Unsupported)
+                        3. (OverlappingLifecycle, Unlisted)
+                        4. (EOL, Supported)
+                        5. (Active - EolSoon, Supported)
+                        // these are not covered
+                        6. (Unlisted, Listed)
+                        7. (EOL, Unsupported | Unlisted)
+                        8. (Listed, Unlisted)
+                    */
+
+                    // Case 1
+                    if (isActive && isSupported)
+                    {
+                        // nothing to do
+                    }
+                    // Case 2
+                    else if (isActive && isUnsupported)
+                    {
+                        unsupportedActiveRelease.Add(cycle.Cycle);
+                    }
+                    // Case 3
+                    else if (hasOverlappingLifecycle && !isSupported && !isUnsupported)
+                    {
+                        missingReleases.Add(cycle.Cycle);
+                    }
+                    // Case 4
+                    else if (!isActive && isSupported)
+                    {
+                        supportedUnActiveReleases.Add(cycle.Cycle);
+                    }            
+
+                    if (isActive && support.EolDate < threeMonthsDate)
+                    {
+                        soonEolReleases.Add(cycle.Cycle);
+                    }
+                }
+
+                ReportDistribution reportDistribution = new(distro.Name, activeReleases, unsupportedActiveRelease, soonEolReleases, supportedUnActiveReleases, missingReleases);
+                reportFamily.Distributions.Add(reportDistribution);
+            }
+        }
+
+        return report;
+    }
+}

--- a/src/ReleaseReport/ReleaseReportGenerator.cs
+++ b/src/ReleaseReport/ReleaseReportGenerator.cs
@@ -65,11 +65,12 @@ public class ReleaseReportGenerator
                         2. (Active, Unsupported)
                         3. (OverlappingLifecycle, Unlisted)
                         4. (EOL, Supported)
-                        5. (Active - EolSoon, Supported)
-                        6. (EOL, Unsupported | Unlisted)
+                        5. (EOL, Unsupported)
+                        6. (Active - EolSoon, Supported)
                         // these are not covered
                         7. (Listed, Unlisted)
-                        8. (Unlisted, Listed)
+                        8. (EOL, Unlisted)
+                        9. (Unlisted, Listed)
                     */
 
                     // Case 1
@@ -92,20 +93,20 @@ public class ReleaseReportGenerator
                     {
                         supportedUnActiveReleases.Add(cycle.Cycle);
                     }
-                    // Case 6
-                    else if (!isActive && !isSupported)
+                    // Case 5
+                    else if (!isActive && isUnsupported)
                     {
                         unsupportedUnActiveReleases.Add(cycle.Cycle);
                     }
 
-                    // Case 5
+                    // Case 6
                     if (isActive && support.EolDate < threeMonthsDate)
                     {
                         soonEolReleases.Add(cycle.Cycle);
                     }
                 }
 
-                ReportDistribution reportDistribution = new(distro.Name, activeReleases, unsupportedActiveRelease, soonEolReleases, supportedUnActiveReleases, missingReleases);
+                ReportDistribution reportDistribution = new(distro.Name, activeReleases, unsupportedActiveRelease, soonEolReleases, supportedUnActiveReleases, unsupportedUnActiveReleases, missingReleases);
                 reportFamily.Distributions.Add(reportDistribution);
             }
         }

--- a/src/ReleaseReport/ReleaseReportGenerator.cs
+++ b/src/ReleaseReport/ReleaseReportGenerator.cs
@@ -26,6 +26,7 @@ public class ReleaseReportGenerator
                 List<string> unsupportedActiveRelease = [];
                 List<string> soonEolReleases = [];
                 List<string> supportedUnActiveReleases = [];
+                List<string> unsupportedUnActiveReleases = [];
                 List<string> missingReleases = [];
                 
                 try
@@ -65,10 +66,10 @@ public class ReleaseReportGenerator
                         3. (OverlappingLifecycle, Unlisted)
                         4. (EOL, Supported)
                         5. (Active - EolSoon, Supported)
+                        6. (EOL, Unsupported | Unlisted)
                         // these are not covered
-                        6. (Unlisted, Listed)
-                        7. (EOL, Unsupported | Unlisted)
-                        8. (Listed, Unlisted)
+                        7. (Listed, Unlisted)
+                        8. (Unlisted, Listed)
                     */
 
                     // Case 1
@@ -90,8 +91,14 @@ public class ReleaseReportGenerator
                     else if (!isActive && isSupported)
                     {
                         supportedUnActiveReleases.Add(cycle.Cycle);
-                    }            
+                    }
+                    // Case 6
+                    else if (!isActive && !isSupported)
+                    {
+                        unsupportedUnActiveReleases.Add(cycle.Cycle);
+                    }
 
+                    // Case 5
                     if (isActive && support.EolDate < threeMonthsDate)
                     {
                         soonEolReleases.Add(cycle.Cycle);

--- a/src/SupportedOsMd/Program.cs
+++ b/src/SupportedOsMd/Program.cs
@@ -9,16 +9,12 @@ if (args.Length is 0 || !int.TryParse(args[0], out int ver))
 }
 
 string version = $"{ver}.0";
-string baseDefaultURL = "https://raw.githubusercontent.com/dotnet/core/main/release-notes/";
-string baseUrl = args.Length > 1 ? args[1] : baseDefaultURL;
-bool preferWeb = baseUrl.StartsWith("https");
-string supportJson = baseUrl;
+string? baseUrl = args.Length > 1 ? args[1] : null;
+string supportJson = baseUrl ?? string.Empty;
 
 if (!supportJson.EndsWith(".json"))
 {
-    supportJson = preferWeb ?
-        $"{baseUrl}/{version}/supported-os.json" :
-        Path.Combine(baseUrl, version,"supported-os.json");
+    supportJson = ReleaseNotes.GetUri(ReleaseNotes.SupportedOS, version, baseUrl);
 }
 
 string template = $"supported-os-template{ver}.md";
@@ -29,6 +25,7 @@ FileStream stream = File.Open(file, FileMode.Create);
 StreamWriter writer = new(stream);
 SupportedOSMatrix? matrix = null;
 Link pageLinks = new();
+bool preferWeb = supportJson.StartsWith("https");
 
 if (preferWeb)
 {

--- a/src/Test/Program.cs
+++ b/src/Test/Program.cs
@@ -10,4 +10,4 @@ if (releases is null)
 }
 
 var json = JsonSerializer.Serialize(releases, MajorReleaseOverviewSerializerContext.Default.MajorReleaseOverview);
-File.WriteAllText("releases.json", json);
+File.WriteAllText(ReleaseNotes.Releases, json);

--- a/src/UpdateReleasesIndex/Program.cs
+++ b/src/UpdateReleasesIndex/Program.cs
@@ -1,8 +1,4 @@
-﻿using System.ComponentModel.Design;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices.Marshalling;
-using System.Text.Json;
-using System.Text.Json.Nodes;
+﻿using System.Text.Json;
 using DotnetRelease;
 
 const string majorReleaseFile = "releases.json";

--- a/src/UpdateReleasesIndex/Program.cs
+++ b/src/UpdateReleasesIndex/Program.cs
@@ -64,7 +64,7 @@ static void ProcessMajorRelease(MajorReleaseOverview majorReleaseOverview, strin
             continue;
         }
         var releaseJsonUrl = $"{ReleaseNotes.OfficialBaseUri}{channelVersion}/{folder}/{patchReleaseFile}";
-        string patchReleaseJson = Path.Combine(dir, folder, "release.json");
+        string patchReleaseJson = Path.Combine(dir, folder, ReleaseNotes.PatchRelease);
 
         var patchReleaseOverview = new PatchReleaseOverview(
             channelVersion,
@@ -95,7 +95,7 @@ static void ProcessMajorRelease(MajorReleaseOverview majorReleaseOverview, strin
         majorReleaseOverview.OsPackagesInfoUri,
         patchReleases);
 
-    string patchReleasesIndexJson = Path.Combine(dir, "patch-releases-index.json");
+    string patchReleasesIndexJson = Path.Combine(dir, ReleaseNotes.PatchReleasesIndex);
     WritePatchReleasesIndex(index, patchReleasesIndexJson);
 }
 

--- a/src/src.sln
+++ b/src/src.sln
@@ -21,6 +21,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test", "Test\Test.csproj", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UpdateReleasesIndex", "UpdateReleasesIndex\UpdateReleasesIndex.csproj", "{1CC51404-5AB9-49BA-8BE7-6263259F02E9}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReleaseReport", "ReleaseReport\ReleaseReport.csproj", "{0A34777F-E4DC-4E37-A2CF-4B2110B60B47}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -63,6 +65,10 @@ Global
 		{1CC51404-5AB9-49BA-8BE7-6263259F02E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1CC51404-5AB9-49BA-8BE7-6263259F02E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1CC51404-5AB9-49BA-8BE7-6263259F02E9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0A34777F-E4DC-4E37-A2CF-4B2110B60B47}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0A34777F-E4DC-4E37-A2CF-4B2110B60B47}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0A34777F-E4DC-4E37-A2CF-4B2110B60B47}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0A34777F-E4DC-4E37-A2CF-4B2110B60B47}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This includes https://github.com/richlander/distroessed/pull/6 so better doing this only after the other one :) I extracted the generation of the `ReportOverview` into a reusable part and used it in `distroessed` as example (and my own generator). Not sure if you like that change or if you have something different/similar in mind anyway.