### PR TITLE
Remove baseDirectory from HalLinkGenerator

### DIFF
--- a/src/UpdateIndexes/HalLinkGenerator.cs
+++ b/src/UpdateIndexes/HalLinkGenerator.cs
@@ -7,10 +7,8 @@ public class HalLinkGenerator(string rootPath, string urlRootPath)
     private readonly string _rootPath = rootPath ?? throw new ArgumentNullException(nameof(rootPath));
     private readonly string _urlRootPath = urlRootPath ?? throw new ArgumentNullException(nameof(urlRootPath));
 
-    public Dictionary<string, HalLink> Generate(string baseDirectory, IEnumerable<FileLink> fileLinks, Func<FileLink, string, string> titleGenerator, Func<string, LinkStyle, string> urlGenerator)
+    public Dictionary<string, HalLink> Generate(IEnumerable<FileLink> fileLinks, Func<FileLink, string, string> titleGenerator, Func<string, LinkStyle, string> urlGenerator)
     {
-        if (baseDirectory == null)
-            throw new ArgumentNullException(nameof(baseDirectory));
         if (fileLinks == null)
             throw new ArgumentNullException(nameof(fileLinks));
         if (titleGenerator == null)
@@ -23,7 +21,7 @@ public class HalLinkGenerator(string rootPath, string urlRootPath)
 
         foreach (var fileLink in fileLinks)
         {
-            var filePath = Path.Combine(baseDirectory, fileLink.File);
+            var filePath = Path.Combine(_rootPath, fileLink.File);
 
             if (!File.Exists(filePath))
             {
@@ -32,7 +30,7 @@ public class HalLinkGenerator(string rootPath, string urlRootPath)
 
             string filename = fileLink.File;
             string urlRelativePath = Path.GetRelativePath(_urlRootPath, filePath);
-            string relativePath = Path.GetRelativePath(baseDirectory, filePath);
+            string relativePath = Path.GetRelativePath(_rootPath, filePath);
             string name = Path.GetFileNameWithoutExtension(filename).ToLowerInvariant();
             string extension = Path.GetExtension(filename).ToLowerInvariant();
             bool isMarkdown = ".md".Equals(extension, StringComparison.OrdinalIgnoreCase);

--- a/src/UpdateIndexes/HalLinkGenerator.cs
+++ b/src/UpdateIndexes/HalLinkGenerator.cs
@@ -2,10 +2,9 @@ using DotnetRelease;
 
 namespace UpdateIndexes;
 
-public class HalLinkGenerator(string rootPath, string urlRootPath)
+public class HalLinkGenerator(string rootPath)
 {
     private readonly string _rootPath = rootPath ?? throw new ArgumentNullException(nameof(rootPath));
-    private readonly string _urlRootPath = urlRootPath ?? throw new ArgumentNullException(nameof(urlRootPath));
 
     public Dictionary<string, HalLink> Generate(IEnumerable<FileLink> fileLinks, Func<FileLink, string, string> titleGenerator, Func<string, LinkStyle, string> urlGenerator)
     {
@@ -29,7 +28,6 @@ public class HalLinkGenerator(string rootPath, string urlRootPath)
             }
 
             string filename = fileLink.File;
-            string urlRelativePath = Path.GetRelativePath(_urlRootPath, filePath);
             string relativePath = Path.GetRelativePath(_rootPath, filePath);
             string name = Path.GetFileNameWithoutExtension(filename).ToLowerInvariant();
             string extension = Path.GetExtension(filename).ToLowerInvariant();
@@ -49,7 +47,7 @@ public class HalLinkGenerator(string rootPath, string urlRootPath)
                 if (fileLink.Style.HasFlag(style))
                 {
                     result[selfKey ?? (isMarkdown ? $"{name}-{(style == LinkStyle.Prod ? "markdown-raw" : "markdown")}" : name)] =
-                        new HalLink(urlGenerator(urlRelativePath, style))
+                        new HalLink(urlGenerator(relativePath, style))
                         {
                             Relative = relativePath,
                             Title = isMarkdown

--- a/src/UpdateIndexes/HistoryIndexFiles.cs
+++ b/src/UpdateIndexes/HistoryIndexFiles.cs
@@ -77,7 +77,6 @@ public class HistoryIndexFiles
                 Console.WriteLine($"Processing month: {month.Month} in year: {year.Year}");
                 var monthPath = Path.Combine(yearPath, month.Month);
                 var monthHistoryLinks = halLinkGenerator.Generate(
-                    monthPath,
                     HistoryFileMappings.Values,
                     (fileLink, key) => key == HalTerms.Self ? $"Release history for {year.Year}-{month.Month}" : fileLink.Title,
                     urlGenerator);
@@ -115,7 +114,6 @@ public class HistoryIndexFiles
             }
 
             var yearHalLinks = halLinkGenerator.Generate(
-                yearPath,
                 HistoryFileMappings.Values,
                 (fileLink, key) => key == HalTerms.Self ? $"Release history for {year.Year}" : fileLink.Title,
                 urlGenerator);
@@ -147,7 +145,6 @@ public class HistoryIndexFiles
             // for the overall index
 
             var overallYearHalLinks = halLinkGenerator.Generate(
-                yearPath,
                 HistoryFileMappings.Values,
                 (fileLink, key) => key == HalTerms.Self ? $"Release history for {year.Year}" : fileLink.Title,
                 urlGenerator);
@@ -164,7 +161,6 @@ public class HistoryIndexFiles
         }
 
         var fullIndexLinks = halLinkGenerator.Generate(
-            rootPath,
             HistoryFileMappings.Values,
             (fileLink, key) => key == HalTerms.Self ? "History of .NET releases" : fileLink.Title,
             urlGenerator);

--- a/src/UpdateIndexes/HistoryIndexFiles.cs
+++ b/src/UpdateIndexes/HistoryIndexFiles.cs
@@ -49,7 +49,7 @@ public class HistoryIndexFiles
 
         var numericStringComparer = StringComparer.Create(CultureInfo.InvariantCulture, CompareOptions.NumericOrdering);
         
-        var halLinkGenerator = new HalLinkGenerator(rootPath, Path.GetDirectoryName(rootPath)!);
+        var halLinkGenerator = new HalLinkGenerator(rootPath);
         
         var urlGenerator = (string relativePath, LinkStyle style) => style == LinkStyle.Prod 
             ? $"https://raw.githubusercontent.com/richlander/core/main/release-notes/{relativePath}"


### PR DESCRIPTION
Simplify HalLinkGenerator by removing redundant path parameters to ensure consistent relative path calculations and correct URL generation.

The previous implementation caused URLs to be generated with a double "release-notes/" path (e.g., `.../release-notes/release-notes/...`) because `urlRelativePath` was incorrectly calculated relative to a parent directory while the `urlGenerator` also added the "release-notes/" prefix. This change ensures all relative paths are consistently calculated from the `_rootPath`, fixing the URL generation and simplifying the code.