### PR TITLE
Implement dynamic table re-sizing

### DIFF
--- a/src/CveMarkdown/CveReport.cs
+++ b/src/CveMarkdown/CveReport.cs
@@ -57,12 +57,12 @@ public static class CveReport
 
         foreach (Cve cve in cves.Cves)
         {
-            cveTable.NewRow();
-            cveTable.WriteColumn($"[{cve.Id}][{cve.Id}]");
-            cveTable.WriteColumn(cve.Description);
-            cveTable.WriteColumn(cve.Product);
-            cveTable.WriteColumn(Join(cve.Platforms));
-            cveTable.WriteColumn(cve?.Cvss ?? "");
+            cveTable.NewRow()
+                    .WriteColumn($"[{cve.Id}][{cve.Id}]")
+                    .WriteColumn(cve.Description)
+                    .WriteColumn(cve.Product)
+                    .WriteColumn(Join(cve.Platforms))
+                    .WriteColumn(cve?.Cvss ?? "");
         }
         
         writer.Write(cveTable);
@@ -80,12 +80,12 @@ public static class CveReport
         {
             foreach (var package in cve.Packages)
             {
-                packageTable.NewRow();
-                packageTable.WriteColumn($"[{cve.Id}][{cve.Id}]");
-                packageTable.WriteColumn(Report.MakePackageString(package.Name));
-                packageTable.WriteColumn($">={package.MinVulnerableVersion}");
-                packageTable.WriteColumn($"<={package.MaxVulnerableVersion}");
-                packageTable.WriteColumn(package.FixedVersion);
+                packageTable.NewRow()
+                           .WriteColumn($"[{cve.Id}][{cve.Id}]")
+                           .WriteColumn(Report.MakePackageString(package.Name))
+                           .WriteColumn($">={package.MinVulnerableVersion}")
+                           .WriteColumn($"<={package.MaxVulnerableVersion}")
+                           .WriteColumn(package.FixedVersion);
             }
         }
         
@@ -107,10 +107,10 @@ public static class CveReport
 
         foreach (Commit commit in cves.Commits)
         {
-            commitTable.NewRow();
-            commitTable.WriteColumn($"[{commit.Cve}][{commit.Cve}]");
-            commitTable.WriteColumn(Report.MakeLinkFromBestSource(commit, commit.Branch, cves.Source.BranchUrl, null));
-            commitTable.WriteColumn(Report.MakeLinkFromBestSource(commit, commit.Hash, cves.Source.CommitUrl, commit.Url));
+            commitTable.NewRow()
+                       .WriteColumn($"[{commit.Cve}][{commit.Cve}]")
+                       .WriteColumn(Report.MakeLinkFromBestSource(commit, commit.Branch, cves.Source.BranchUrl, null))
+                       .WriteColumn(Report.MakeLinkFromBestSource(commit, commit.Hash, cves.Source.CommitUrl, commit.Url));
         }
         
         writer.Write(commitTable);

--- a/src/CveMarkdown/CveReport.cs
+++ b/src/CveMarkdown/CveReport.cs
@@ -51,27 +51,28 @@ public static class CveReport
     {
         // CVE table
         string[] cveLabels = ["CVE", "Description", "Product", "Platforms", "CVSS"];
-        int[] cveLengths = [16, 20, 16, 16, 20];
-        Table cveTable = new(Writer.GetWriter(writer), cveLengths);
+        Table cveTable = new(Writer.GetWriter(writer));
 
         cveTable.WriteHeader(cveLabels);
 
         foreach (Cve cve in cves.Cves)
-        {cveTable.WriteColumn($"[{cve.Id}][{cve.Id}]");
+        {
+            cveTable.WriteColumn($"[{cve.Id}][{cve.Id}]");
             cveTable.WriteColumn(cve.Description);
             cveTable.WriteColumn(cve.Product);
             cveTable.WriteColumn(Join(cve.Platforms));
             cveTable.WriteColumn(cve?.Cvss ?? "");
             cveTable.EndRow();
         }
+        
+        cveTable.Render();
     }
 
     public static void WritePackageTable(CveSet cves, StreamWriter writer)
     {
         // Package version table
         string[] packageLabels = ["CVE", "Package", "Min Version", "Max Version", "Fixed Version"];
-        int[] packageLengths = [16, 16, 12, 12, 16];
-        Table packageTable = new(Writer.GetWriter(writer), packageLengths);
+        Table packageTable = new(Writer.GetWriter(writer));
 
         packageTable.WriteHeader(packageLabels);
 
@@ -87,6 +88,8 @@ public static class CveReport
                 packageTable.EndRow();
             }
         }
+        
+        packageTable.Render();
     }
 
     public static void WriteCommitTable(CveSet cves, StreamWriter writer)
@@ -98,8 +101,7 @@ public static class CveReport
 
         // Commits table
         string[] commitLabels = ["CVE", "Branch", "Commit"];
-        int[] commitLengths = [30, 20, 60];
-        Table commitTable = new(Writer.GetWriter(writer), commitLengths);
+        Table commitTable = new(Writer.GetWriter(writer));
 
         commitTable.WriteHeader(commitLabels);
 
@@ -110,6 +112,8 @@ public static class CveReport
             commitTable.WriteColumn(Report.MakeLinkFromBestSource(commit, commit.Hash, cves.Source.CommitUrl, commit.Url));
             commitTable.EndRow();
         }
+        
+        commitTable.Render();
 
         writer.WriteLine();
 

--- a/src/CveMarkdown/CveReport.cs
+++ b/src/CveMarkdown/CveReport.cs
@@ -53,16 +53,17 @@ public static class CveReport
         string[] cveLabels = ["CVE", "Description", "Product", "Platforms", "CVSS"];
         Table cveTable = new();
 
-        cveTable.WriteHeader(cveLabels);
+        cveTable.AddHeader(cveLabels);
 
         foreach (Cve cve in cves.Cves)
         {
-            cveTable.NewRow()
-                    .WriteColumn($"[{cve.Id}][{cve.Id}]")
-                    .WriteColumn(cve.Description)
-                    .WriteColumn(cve.Product)
-                    .WriteColumn(Join(cve.Platforms))
-                    .WriteColumn(cve?.Cvss ?? "");
+            cveTable.AddRow(
+                $"[{cve.Id}][{cve.Id}]",
+                cve.Description,
+                cve.Product,
+                Join(cve.Platforms),
+                cve?.Cvss ?? ""
+            );
         }
         
         writer.Write(cveTable);
@@ -74,18 +75,19 @@ public static class CveReport
         string[] packageLabels = ["CVE", "Package", "Min Version", "Max Version", "Fixed Version"];
         Table packageTable = new();
 
-        packageTable.WriteHeader(packageLabels);
+        packageTable.AddHeader(packageLabels);
 
         foreach (Cve cve in cves.Cves)
         {
             foreach (var package in cve.Packages)
             {
-                packageTable.NewRow()
-                           .WriteColumn($"[{cve.Id}][{cve.Id}]")
-                           .WriteColumn(Report.MakePackageString(package.Name))
-                           .WriteColumn($">={package.MinVulnerableVersion}")
-                           .WriteColumn($"<={package.MaxVulnerableVersion}")
-                           .WriteColumn(package.FixedVersion);
+                packageTable.AddRow(
+                    $"[{cve.Id}][{cve.Id}]",
+                    Report.MakePackageString(package.Name),
+                    $">={package.MinVulnerableVersion}",
+                    $"<={package.MaxVulnerableVersion}",
+                    package.FixedVersion
+                );
             }
         }
         
@@ -103,14 +105,15 @@ public static class CveReport
         string[] commitLabels = ["CVE", "Branch", "Commit"];
         Table commitTable = new();
 
-        commitTable.WriteHeader(commitLabels);
+        commitTable.AddHeader(commitLabels);
 
         foreach (Commit commit in cves.Commits)
         {
-            commitTable.NewRow()
-                       .WriteColumn($"[{commit.Cve}][{commit.Cve}]")
-                       .WriteColumn(Report.MakeLinkFromBestSource(commit, commit.Branch, cves.Source.BranchUrl, null))
-                       .WriteColumn(Report.MakeLinkFromBestSource(commit, commit.Hash, cves.Source.CommitUrl, commit.Url));
+            commitTable.AddRow(
+                $"[{commit.Cve}][{commit.Cve}]",
+                Report.MakeLinkFromBestSource(commit, commit.Branch, cves.Source.BranchUrl, null),
+                Report.MakeLinkFromBestSource(commit, commit.Hash, cves.Source.CommitUrl, commit.Url)
+            );
         }
         
         writer.Write(commitTable);

--- a/src/CveMarkdown/CveReport.cs
+++ b/src/CveMarkdown/CveReport.cs
@@ -51,28 +51,28 @@ public static class CveReport
     {
         // CVE table
         string[] cveLabels = ["CVE", "Description", "Product", "Platforms", "CVSS"];
-        Table cveTable = new(Writer.GetWriter(writer));
+        Table cveTable = new();
 
         cveTable.WriteHeader(cveLabels);
 
         foreach (Cve cve in cves.Cves)
         {
+            cveTable.NewRow();
             cveTable.WriteColumn($"[{cve.Id}][{cve.Id}]");
             cveTable.WriteColumn(cve.Description);
             cveTable.WriteColumn(cve.Product);
             cveTable.WriteColumn(Join(cve.Platforms));
             cveTable.WriteColumn(cve?.Cvss ?? "");
-            cveTable.EndRow();
         }
         
-        cveTable.Render();
+        writer.Write(cveTable);
     }
 
     public static void WritePackageTable(CveSet cves, StreamWriter writer)
     {
         // Package version table
         string[] packageLabels = ["CVE", "Package", "Min Version", "Max Version", "Fixed Version"];
-        Table packageTable = new(Writer.GetWriter(writer));
+        Table packageTable = new();
 
         packageTable.WriteHeader(packageLabels);
 
@@ -80,16 +80,16 @@ public static class CveReport
         {
             foreach (var package in cve.Packages)
             {
+                packageTable.NewRow();
                 packageTable.WriteColumn($"[{cve.Id}][{cve.Id}]");
                 packageTable.WriteColumn(Report.MakePackageString(package.Name));
                 packageTable.WriteColumn($">={package.MinVulnerableVersion}");
                 packageTable.WriteColumn($"<={package.MaxVulnerableVersion}");
                 packageTable.WriteColumn(package.FixedVersion);
-                packageTable.EndRow();
             }
         }
         
-        packageTable.Render();
+        writer.Write(packageTable);
     }
 
     public static void WriteCommitTable(CveSet cves, StreamWriter writer)
@@ -101,19 +101,19 @@ public static class CveReport
 
         // Commits table
         string[] commitLabels = ["CVE", "Branch", "Commit"];
-        Table commitTable = new(Writer.GetWriter(writer));
+        Table commitTable = new();
 
         commitTable.WriteHeader(commitLabels);
 
         foreach (Commit commit in cves.Commits)
         {
+            commitTable.NewRow();
             commitTable.WriteColumn($"[{commit.Cve}][{commit.Cve}]");
             commitTable.WriteColumn(Report.MakeLinkFromBestSource(commit, commit.Branch, cves.Source.BranchUrl, null));
             commitTable.WriteColumn(Report.MakeLinkFromBestSource(commit, commit.Hash, cves.Source.CommitUrl, commit.Url));
-            commitTable.EndRow();
         }
         
-        commitTable.Render();
+        writer.Write(commitTable);
 
         writer.WriteLine();
 

--- a/src/LinuxPackagesMd/Program.cs
+++ b/src/LinuxPackagesMd/Program.cs
@@ -95,11 +95,11 @@ static void WritePackageOverview(StreamWriter writer, OSPackagesOverview package
 
 
         var pkgLink = links.AddIndexReferenceLink(package.Id, $"https://pkgs.org/search/?q={package.Id}");
-        packageTable.NewRow();
-        packageTable.WriteColumn(pkgLink);
-        packageTable.WriteColumn(package.Name);
-        packageTable.WriteColumn(string.Join(" ; ", package.RequiredScenarios ?? []));
-        packageTable.WriteColumn(buffer.ToString());
+        packageTable.NewRow()
+                    .WriteColumn(pkgLink)
+                    .WriteColumn(package.Name)
+                    .WriteColumn(string.Join(" ; ", package.RequiredScenarios ?? []))
+                    .WriteColumn(buffer.ToString());
     }
     
     writer.Write(packageTable);

--- a/src/LinuxPackagesMd/Program.cs
+++ b/src/LinuxPackagesMd/Program.cs
@@ -77,7 +77,7 @@ writtenFile.Close();
 static void WritePackageOverview(StreamWriter writer, OSPackagesOverview packageOverview, Link links)
 {
     ReadOnlySpan<string> packageLabels = ["Id", "Name", "Required scenarios", "Notes"];
-    Table packageTable = new(Writer.GetWriter(writer));
+    Table packageTable = new();
   
     packageTable.WriteHeader(packageLabels);
 
@@ -95,14 +95,14 @@ static void WritePackageOverview(StreamWriter writer, OSPackagesOverview package
 
 
         var pkgLink = links.AddIndexReferenceLink(package.Id, $"https://pkgs.org/search/?q={package.Id}");
+        packageTable.NewRow();
         packageTable.WriteColumn(pkgLink);
         packageTable.WriteColumn(package.Name);
         packageTable.WriteColumn(string.Join(" ; ", package.RequiredScenarios ?? []));
         packageTable.WriteColumn(buffer.ToString());
-        packageTable.EndRow();
     }
     
-    packageTable.Render();
+    writer.Write(packageTable);
 
     foreach (var refLink in links.GetReferenceLinkAnchors())
     {

--- a/src/LinuxPackagesMd/Program.cs
+++ b/src/LinuxPackagesMd/Program.cs
@@ -77,8 +77,7 @@ writtenFile.Close();
 static void WritePackageOverview(StreamWriter writer, OSPackagesOverview packageOverview, Link links)
 {
     ReadOnlySpan<string> packageLabels = ["Id", "Name", "Required scenarios", "Notes"];
-    int[] packageColumns = [16, 12, 16, 32];
-    Table packageTable = new(Writer.GetWriter(writer), packageColumns);
+    Table packageTable = new(Writer.GetWriter(writer));
   
     packageTable.WriteHeader(packageLabels);
 
@@ -102,6 +101,8 @@ static void WritePackageOverview(StreamWriter writer, OSPackagesOverview package
         packageTable.WriteColumn(buffer.ToString());
         packageTable.EndRow();
     }
+    
+    packageTable.Render();
 
     foreach (var refLink in links.GetReferenceLinkAnchors())
     {

--- a/src/LinuxPackagesMd/Program.cs
+++ b/src/LinuxPackagesMd/Program.cs
@@ -76,10 +76,9 @@ writtenFile.Close();
 
 static void WritePackageOverview(StreamWriter writer, OSPackagesOverview packageOverview, Link links)
 {
-    ReadOnlySpan<string> packageLabels = ["Id", "Name", "Required scenarios", "Notes"];
     Table packageTable = new();
   
-    packageTable.WriteHeader(packageLabels);
+    packageTable.AddHeader("Id", "Name", "Required scenarios", "Notes");
 
     foreach (var package in packageOverview.Packages)
     {
@@ -95,11 +94,12 @@ static void WritePackageOverview(StreamWriter writer, OSPackagesOverview package
 
 
         var pkgLink = links.AddIndexReferenceLink(package.Id, $"https://pkgs.org/search/?q={package.Id}");
-        packageTable.NewRow()
-                    .WriteColumn(pkgLink)
-                    .WriteColumn(package.Name)
-                    .WriteColumn(string.Join(" ; ", package.RequiredScenarios ?? []))
-                    .WriteColumn(buffer.ToString());
+        packageTable.AddRow(
+            pkgLink,
+            package.Name,
+            string.Join(" ; ", package.RequiredScenarios ?? []),
+            buffer.ToString()
+        );
     }
     
     writer.Write(packageTable);

--- a/src/MarkdownHelpers/Table.cs
+++ b/src/MarkdownHelpers/Table.cs
@@ -53,17 +53,12 @@ public class Table
 
     public void WriteColumn(string text)
     {
-        ThrowIfTooManyColumns(_currentColumn);
+        if (_currentColumn >= _columnCount)
+        {
+            throw new ArgumentException($"Too many columns. Expected {_columnCount}, but trying to write column {_currentColumn + 1}.");
+        }
         _currentRow[_currentColumn] = text ?? string.Empty;
         _currentColumn++;
-    }
-
-    private void ThrowIfTooManyColumns(int columnIndex)
-    {
-        if (columnIndex >= _columnCount)
-        {
-            throw new ArgumentException($"Too many columns. Expected {_columnCount}, but trying to write column {columnIndex + 1}.");
-        }
     }
     
     public void Render()

--- a/src/MarkdownHelpers/Table.cs
+++ b/src/MarkdownHelpers/Table.cs
@@ -14,15 +14,37 @@ public class Table
     private bool _headerWritten = false;
     
     public bool UseOuterPipes { get; set; } = true;
-    public int MaxTableWidth { get; set; } = (int)(80 * 0.75); // Default to 75% of 80 characters
-    public double PercentileThreshold { get; set; } = 0.5; // Default to 50th percentile (median)
-    public double ToleranceMultiplier { get; set; } = 1.2; // Default to 20% tolerance
+    
+    private double _percentileThreshold = 0.5;
+    private double _toleranceMultiplier = 1.2;
+    
+    public double PercentileThreshold 
+    { 
+        get => _percentileThreshold;
+        set
+        {
+            if (value < 0.0 || value > 1.0)
+                throw new ArgumentOutOfRangeException(nameof(value), "PercentileThreshold must be between 0.0 and 1.0");
+            _percentileThreshold = value;
+        }
+    }
+    
+    public double ToleranceMultiplier 
+    { 
+        get => _toleranceMultiplier;
+        set
+        {
+            if (value <= 0.0)
+                throw new ArgumentOutOfRangeException(nameof(value), "ToleranceMultiplier must be greater than 0.0");
+            _toleranceMultiplier = value;
+        }
+    }
     
     public Table()
     {
     }
 
-    public void NewRow()
+    public Table NewRow()
     {
         if (!_headerWritten)
         {
@@ -43,6 +65,7 @@ public class Table
         // Start new row
         _currentRow = new string[_columnCount];
         _currentColumn = 0;
+        return this;
     }
 
     public void WriteHeader(ReadOnlySpan<string> labels)
@@ -52,20 +75,25 @@ public class Table
             throw new InvalidOperationException("Header has already been written. WriteHeader can only be called once.");
         }
         
+        if (labels.Length == 0)
+        {
+            throw new ArgumentException("Header must have at least one column.", nameof(labels));
+        }
+        
         _columnCount = labels.Length;
         _headers = new string[_columnCount];
         _columnLengths = new List<int>[_columnCount];
         
         for (int i = 0; i < labels.Length; i++)
         {
-            _headers[i] = labels[i];
+            _headers[i] = labels[i] ?? string.Empty;
             _columnLengths[i] = new List<int>();
         }
         _currentRow = new string[_columnCount];
         _headerWritten = true;
     }
 
-    public void WriteColumn(string text)
+    public Table WriteColumn(string text)
     {
         if (!_headerWritten)
         {
@@ -73,12 +101,13 @@ public class Table
         }
         if (_currentColumn >= _columnCount)
         {
-            throw new ArgumentException($"Too many columns. Expected {_columnCount}, but trying to write column {_currentColumn + 1}.");
+            throw new ArgumentOutOfRangeException(nameof(_currentColumn), $"Too many columns. Expected {_columnCount}, but trying to write column {_currentColumn + 1}.");
         }
         string cellText = text ?? string.Empty;
         _currentRow[_currentColumn] = cellText;
         _columnLengths[_currentColumn].Add(cellText.Length);
         _currentColumn++;
+        return this;
     }
     
     public override string ToString()
@@ -154,25 +183,13 @@ public class Table
             sortedLengths.Sort();
             
             // 2. Length of the configured percentile row content
-            int percentileIndex = (int)(sortedLengths.Count * PercentileThreshold);
-            percentileIndex = Math.Min(percentileIndex, sortedLengths.Count - 1);
+            int percentileIndex = Math.Min((int)Math.Ceiling(sortedLengths.Count * PercentileThreshold) - 1, sortedLengths.Count - 1);
+            percentileIndex = Math.Max(0, percentileIndex); // Ensure non-negative
             int percentileLength = sortedLengths[percentileIndex];
             
             // 3. Length of the longest row that is only within tolerance of the percentile
             double tolerance = percentileLength * ToleranceMultiplier;
-            int maxWithinToleranceLength = percentileLength;
-            
-            foreach (int length in sortedLengths)
-            {
-                if (length <= tolerance)
-                {
-                    maxWithinToleranceLength = length;
-                }
-                else
-                {
-                    break; // sortedLengths is sorted, so we can stop here
-                }
-            }
+            int maxWithinToleranceLength = sortedLengths.Where(length => length <= tolerance).DefaultIfEmpty(percentileLength).Last();
             
             // Take the max of the three numbers
             alignmentWidths[col] = Math.Max(headerLength, Math.Max(percentileLength, maxWithinToleranceLength));
@@ -183,8 +200,8 @@ public class Table
     
     private void WriteTableRow(string[] row, int[] columnWidths)
     {
-        int realLength = 0;  // How much space we've actually used
-        int specLength = 0;  // How much space we're supposed to use
+        int actualWidth = 0;  // How much space we've actually used
+        int targetWidth = 0;  // How much space we're supposed to use
         
         for (int col = 0; col < _columnCount; col++)
         {
@@ -209,16 +226,16 @@ public class Table
             
             int postSpace = writeEndPipe ? 2 : 1; // " |" vs " "
             
-            // Track lengths like the original implementation
-            realLength += preSpace + text.Length + postSpace;
-            specLength += preSpace + columnWidths[col] + postSpace;
+            // Track actual vs target widths for smart padding
+            actualWidth += preSpace + text.Length + postSpace;
+            targetWidth += preSpace + columnWidths[col] + postSpace;
             
-            // Only pad if we haven't exceeded the expected width (like original)
-            int remaining = specLength - realLength;
+            // Only pad if we haven't exceeded the expected width
+            int remaining = targetWidth - actualWidth;
             if (remaining > 0)
             {
                 _output.Append(' ', remaining);
-                realLength += remaining;
+                actualWidth += remaining;
             }
             
             _output.Append(writeEndPipe ? " |" : " ");
@@ -228,8 +245,8 @@ public class Table
     
     private void WriteHeaderSeparator(int[] columnWidths)
     {
-        int realLength = 0;  // How much space we've actually used
-        int specLength = 0;  // How much space we're supposed to use
+        int actualWidth = 0;  // How much space we've actually used
+        int targetWidth = 0;  // How much space we're supposed to use
         
         for (int col = 0; col < _columnCount; col++)
         {
@@ -255,10 +272,10 @@ public class Table
             int postSpace = writeEndPipe ? 2 : 1; // " |" vs " "
             
             // Track lengths using the calculated column width
-            realLength += preSpace + columnWidths[col] + postSpace;
-            specLength += preSpace + columnWidths[col] + postSpace;
+            actualWidth += preSpace + columnWidths[col] + postSpace;
+            targetWidth += preSpace + columnWidths[col] + postSpace;
             
-            // For header separator, realLength and specLength should always match
+            // For header separator, actualWidth and targetWidth should always match
             // since we're using the calculated width directly
             
             _output.Append(writeEndPipe ? " |" : " ");

--- a/src/MarkdownHelpers/Table.cs
+++ b/src/MarkdownHelpers/Table.cs
@@ -1,105 +1,181 @@
 namespace MarkdownHelpers;
 
-public class Table(IWriter writer, int[] columns)
+public class Table
 {
-    private readonly IWriter _writer = writer;
-    private readonly int[] _columns = columns;
-    private readonly int _columnMax = columns.Length - 1;
-    private int _column = 0;
-    private int _realLength = 0;
-    private int _specLength = 0;
+    private readonly IWriter _writer;
+    private readonly List<string[]> _rows = new();
+    private string[] _headers = Array.Empty<string>();
+    private string[] _currentRow = Array.Empty<string>();
+    private int _currentColumn = 0;
+    private int _columnCount = 0;
     
     public bool UseOuterPipes { get; set; } = true;
+    public int MaxTableWidth { get; set; } = (int)(80 * 0.75); // Default to 75% of 80 characters
+    
+    public Table(IWriter writer)
+    {
+        _writer = writer;
+    }
+    
+    public Table(IWriter writer, int maxTableWidth)
+    {
+        _writer = writer;
+        MaxTableWidth = maxTableWidth;
+    }
 
     public void EndRow()
     {
-        _column = 0;
-        _realLength = 0;
-        _specLength = 0;
-        _writer.WriteLine();
+        if (_columnCount > 0 && _currentRow.Length > 0)
+        {
+            // Ensure all cells in the row are filled
+            for (int i = _currentColumn; i < _columnCount; i++)
+            {
+                _currentRow[i] = string.Empty;
+            }
+            _rows.Add(_currentRow);
+            _currentRow = new string[_columnCount];
+        }
+        _currentColumn = 0;
     }
 
     public void WriteHeader(ReadOnlySpan<string> labels)
     {
+        _columnCount = labels.Length;
+        _headers = new string[_columnCount];
         for (int i = 0; i < labels.Length; i++)
         {
-            WriteColumn(labels[i]);
+            _headers[i] = labels[i];
         }
-
-        EndRow();
-
-        for (int i = 0; i < labels.Length; i++)
-        {
-            WriteColumn("", '-', true);
-        }
-
-        EndRow();
+        _currentRow = new string[_columnCount];
     }
 
-    public void WriteColumn(string text, char repeatCharacter = ' ', bool headerPolicy = false)
+    public void WriteColumn(string text)
     {
-        ThrowIfTooManyColumns(_column);
-
-        int preSpace = 0;
-        if (_column > 0 || UseOuterPipes)
-        {
-            _writer.Write("| ");
-            preSpace = 2;
-        }
-
-        _writer.Write(text);
-
-        bool lastColumn = _column == _columnMax;
-        bool writeEndPipe = lastColumn && UseOuterPipes;
-        bool endWithText = lastColumn && !UseOuterPipes && !headerPolicy;
-        bool writeRepeatToEnd = headerPolicy && lastColumn && !UseOuterPipes;
-
-        if (endWithText)
-        {
-            return;
-        }
-
-        int postSpace = 1;
-
-        if (writeEndPipe)
-        {
-            postSpace = 2;
-        }
-        else if (writeRepeatToEnd)
-        {
-            postSpace = 0;
-        }
-
-        _realLength +=  preSpace + text.Length + postSpace;
-        _specLength += _columns[_column];
-        _column++;
-
-        int remaining = _specLength - _realLength;
-        if (remaining > 0)
-        {
-            _writer.WriteRepeatCharacter(repeatCharacter, remaining);
-            _realLength += remaining;
-        }
-
-        if (writeRepeatToEnd)
-        {
-            return;
-        }
-
-        _writer.Write(' ');
-
-        if (writeEndPipe)
-        {
-            _writer.Write('|');
-        }
+        ThrowIfTooManyColumns(_currentColumn);
+        _currentRow[_currentColumn] = text ?? string.Empty;
+        _currentColumn++;
     }
 
-    private void ThrowIfTooManyColumns(int count)
+    private void ThrowIfTooManyColumns(int columnIndex)
     {
-        if (count > _columnMax)
+        if (columnIndex >= _columnCount)
         {
-            throw new("Too many columns");
+            throw new ArgumentException($"Too many columns. Expected {_columnCount}, but trying to write column {columnIndex + 1}.");
         }
     }
-
+    
+    public void Render()
+    {
+        if (_columnCount == 0)
+            return;
+            
+        var columnWidths = CalculateColumnWidths();
+        
+        // Write header
+        WriteTableRow(_headers, columnWidths);
+        WriteHeaderSeparator(columnWidths);
+        
+        // Write data rows
+        foreach (var row in _rows)
+        {
+            WriteTableRow(row, columnWidths);
+        }
+    }
+    
+    private int[] CalculateColumnWidths()
+    {
+        if (_columnCount == 0) return Array.Empty<int>();
+        
+        // Calculate widths for reasonable alignment without forcing extreme outliers
+        var alignmentWidths = new int[_columnCount];
+        
+        for (int col = 0; col < _columnCount; col++)
+        {
+            var lengths = new List<int>();
+            
+            // Include header
+            lengths.Add(_headers[col].Length);
+            
+            // Include all content lengths
+            foreach (var row in _rows)
+            {
+                lengths.Add(row[col].Length);
+            }
+            
+            lengths.Sort();
+            
+            // Use 75th percentile as the "reasonable" width for alignment
+            // This prevents extreme outliers from forcing wide columns on everyone
+            int percentileIndex = (int)(lengths.Count * 0.75);
+            percentileIndex = Math.Min(percentileIndex, lengths.Count - 1);
+            
+            alignmentWidths[col] = lengths[percentileIndex];
+        }
+        
+        return alignmentWidths;
+    }
+    
+    private void WriteTableRow(string[] row, int[] columnWidths)
+    {
+        for (int col = 0; col < _columnCount; col++)
+        {
+            if (col > 0 || UseOuterPipes)
+            {
+                _writer.Write("| ");
+            }
+            
+            string text = row[col];
+            _writer.Write(text);
+            
+            bool isLastColumn = col == _columnCount - 1;
+            
+            // For non-last columns, pad to alignment width if content is shorter
+            // If content is longer, just add the separator space and continue
+            if (!isLastColumn)
+            {
+                int padding = columnWidths[col] - text.Length;
+                if (padding > 0)
+                {
+                    _writer.WriteRepeatCharacter(' ', padding);
+                }
+                _writer.Write(" ");
+            }
+            else if (UseOuterPipes)
+            {
+                // For last column with outer pipes, pad if shorter than alignment width
+                int padding = columnWidths[col] - text.Length;
+                if (padding > 0)
+                {
+                    _writer.WriteRepeatCharacter(' ', padding);
+                }
+                _writer.Write(" |");
+            }
+        }
+        _writer.WriteLine();
+    }
+    
+    private void WriteHeaderSeparator(int[] columnWidths)
+    {
+        for (int col = 0; col < _columnCount; col++)
+        {
+            if (col > 0 || UseOuterPipes)
+            {
+                _writer.Write("| ");
+            }
+            
+            _writer.WriteRepeatCharacter('-', columnWidths[col]);
+            
+            bool isLastColumn = col == _columnCount - 1;
+            if (!isLastColumn || UseOuterPipes)
+            {
+                _writer.Write(" ");
+            }
+            
+            if (isLastColumn && UseOuterPipes)
+            {
+                _writer.Write("|");
+            }
+        }
+        _writer.WriteLine();
+    }
 }

--- a/src/SupportedOsMd/Program.cs
+++ b/src/SupportedOsMd/Program.cs
@@ -149,7 +149,6 @@ static void WriteLastUpdatedSection(StreamWriter writer, DateOnly date)
 
 static void WriteFamiliesSection(StreamWriter writer, IList<SupportFamily> families, Link links)
 {
-    ReadOnlySpan<string> labels = ["OS", "Versions", "Architectures", "Lifecycle"];
     int linkCount = 0;
     bool first = true;
 
@@ -168,7 +167,7 @@ static void WriteFamiliesSection(StreamWriter writer, IList<SupportFamily> famil
         Link familyLinks = new(linkCount);
         writer.WriteLine($"## {family.Name}");
         writer.WriteLine();
-        table.WriteHeader(labels);
+        table.AddHeader("OS", "Versions", "Architectures", "Lifecycle");
         List<string> notes = [];
 
         for (int i = 0; i < family.Distributions.Count; i++)
@@ -196,11 +195,7 @@ static void WriteFamiliesSection(StreamWriter writer, IList<SupportFamily> famil
             var lifecycleLink = distro.Lifecycle is null ? "None" :
                 familyLinks.AddIndexReferenceLink("Lifecycle", distro.Lifecycle);
 
-            table.NewRow()
-                 .WriteColumn(distroLink)
-                 .WriteColumn(versions)
-                 .WriteColumn(Join(distro.Architectures))
-                 .WriteColumn(lifecycleLink);
+            table.AddRow(distroLink, versions, Join(distro.Architectures), lifecycleLink);
             linkCount = familyLinks.Index;
 
             if (distro.Notes is { Count: > 0 })
@@ -239,15 +234,11 @@ static void WriteLibcSection(StreamWriter writer, IList<SupportLibc> supportedLi
 {
     string[] columnLabels = ["Libc", "Version", "Architectures", "Source"];
     Table table = new();
-    table.WriteHeader(columnLabels);
+    table.AddHeader(columnLabels);
 
     foreach (SupportLibc libc in supportedLibc)
     {
-        table.NewRow()
-             .WriteColumn(libc.Name)
-             .WriteColumn(libc.Version)
-             .WriteColumn(Join(libc.Architectures))
-             .WriteColumn(libc.Source);
+        table.AddRow(libc.Name, libc.Version, Join(libc.Architectures), libc.Source);
     }
     
     writer.Write(table);
@@ -290,7 +281,7 @@ static async Task WriteUnSupportedSection(StreamWriter writer, IList<SupportFami
     string[] labels = ["OS", "Version", "Date"];
     Table table = new();
 
-    table.WriteHeader(labels);
+    table.AddHeader(labels);
 
     foreach (var entry in orderedEolCycles)
     {
@@ -302,10 +293,7 @@ static async Task WriteUnSupportedSection(StreamWriter writer, IList<SupportFami
             distroVersion = SupportedOS.PrettyifyWindowsVersion(distroVersion);
         }
 
-        table.NewRow()
-             .WriteColumn(distroName)
-             .WriteColumn(distroVersion)
-             .WriteColumn(eol);
+        table.AddRow(distroName, distroVersion, eol);
     }
     
     writer.Write(table);

--- a/src/SupportedOsMd/Program.cs
+++ b/src/SupportedOsMd/Program.cs
@@ -164,7 +164,7 @@ static void WriteFamiliesSection(StreamWriter writer, IList<SupportFamily> famil
             writer.WriteLine();
         }
 
-        Table table = new(Writer.GetWriter(writer));
+        Table table = new();
         Link familyLinks = new(linkCount);
         writer.WriteLine($"## {family.Name}");
         writer.WriteLine();
@@ -193,6 +193,7 @@ static void WriteFamiliesSection(StreamWriter writer, IList<SupportFamily> famil
             }
 
             var distroLink = familyLinks.AddIndexReferenceLink(distro.Name, distro.Link);
+            table.NewRow();
             table.WriteColumn(distroLink);
             table.WriteColumn(versions);
             table.WriteColumn(Join(distro.Architectures));
@@ -200,7 +201,6 @@ static void WriteFamiliesSection(StreamWriter writer, IList<SupportFamily> famil
                 familyLinks.AddIndexReferenceLink("Lifecycle", distro.Lifecycle);
 
             table.WriteColumn(lifecycleLink);
-            table.EndRow();
             linkCount = familyLinks.Index;
 
             if (distro.Notes is { Count: > 0 })
@@ -212,7 +212,7 @@ static void WriteFamiliesSection(StreamWriter writer, IList<SupportFamily> famil
             }
         }
         
-        table.Render();
+        writer.Write(table);
 
         if (notes.Count > 0)
         {
@@ -238,19 +238,19 @@ static void WriteFamiliesSection(StreamWriter writer, IList<SupportFamily> famil
 static void WriteLibcSection(StreamWriter writer, IList<SupportLibc> supportedLibc)
 {
     string[] columnLabels = ["Libc", "Version", "Architectures", "Source"];
-    Table table = new(Writer.GetWriter(writer));
+    Table table = new();
     table.WriteHeader(columnLabels);
 
     foreach (SupportLibc libc in supportedLibc)
     {
+        table.NewRow();
         table.WriteColumn(libc.Name);
         table.WriteColumn(libc.Version);
         table.WriteColumn(Join(libc.Architectures));
         table.WriteColumn(libc.Source);
-        table.EndRow();
     }
     
-    table.Render();
+    writer.Write(table);
 }
 
 static void WriteNotesSection(StreamWriter writer, IList<string> notes)
@@ -288,7 +288,7 @@ static async Task WriteUnSupportedSection(StreamWriter writer, IList<SupportFami
     }
 
     string[] labels = ["OS", "Version", "Date"];
-    Table table = new(Writer.GetWriter(writer));
+    Table table = new();
 
     table.WriteHeader(labels);
 
@@ -302,13 +302,13 @@ static async Task WriteUnSupportedSection(StreamWriter writer, IList<SupportFami
             distroVersion = SupportedOS.PrettyifyWindowsVersion(distroVersion);
         }
 
+        table.NewRow();
         table.WriteColumn(distroName);
         table.WriteColumn(distroVersion);
         table.WriteColumn(eol);
-        table.EndRow();
     }
     
-    table.Render();
+    writer.Write(table);
 }
 
 static string GetEolTextForCycle(SupportCycle? cycle)

--- a/src/SupportedOsMd/Program.cs
+++ b/src/SupportedOsMd/Program.cs
@@ -193,14 +193,14 @@ static void WriteFamiliesSection(StreamWriter writer, IList<SupportFamily> famil
             }
 
             var distroLink = familyLinks.AddIndexReferenceLink(distro.Name, distro.Link);
-            table.NewRow();
-            table.WriteColumn(distroLink);
-            table.WriteColumn(versions);
-            table.WriteColumn(Join(distro.Architectures));
             var lifecycleLink = distro.Lifecycle is null ? "None" :
                 familyLinks.AddIndexReferenceLink("Lifecycle", distro.Lifecycle);
 
-            table.WriteColumn(lifecycleLink);
+            table.NewRow()
+                 .WriteColumn(distroLink)
+                 .WriteColumn(versions)
+                 .WriteColumn(Join(distro.Architectures))
+                 .WriteColumn(lifecycleLink);
             linkCount = familyLinks.Index;
 
             if (distro.Notes is { Count: > 0 })
@@ -243,11 +243,11 @@ static void WriteLibcSection(StreamWriter writer, IList<SupportLibc> supportedLi
 
     foreach (SupportLibc libc in supportedLibc)
     {
-        table.NewRow();
-        table.WriteColumn(libc.Name);
-        table.WriteColumn(libc.Version);
-        table.WriteColumn(Join(libc.Architectures));
-        table.WriteColumn(libc.Source);
+        table.NewRow()
+             .WriteColumn(libc.Name)
+             .WriteColumn(libc.Version)
+             .WriteColumn(Join(libc.Architectures))
+             .WriteColumn(libc.Source);
     }
     
     writer.Write(table);
@@ -302,10 +302,10 @@ static async Task WriteUnSupportedSection(StreamWriter writer, IList<SupportFami
             distroVersion = SupportedOS.PrettyifyWindowsVersion(distroVersion);
         }
 
-        table.NewRow();
-        table.WriteColumn(distroName);
-        table.WriteColumn(distroVersion);
-        table.WriteColumn(eol);
+        table.NewRow()
+             .WriteColumn(distroName)
+             .WriteColumn(distroVersion)
+             .WriteColumn(eol);
     }
     
     writer.Write(table);

--- a/src/SupportedOsMd/Program.cs
+++ b/src/SupportedOsMd/Program.cs
@@ -150,7 +150,6 @@ static void WriteLastUpdatedSection(StreamWriter writer, DateOnly date)
 static void WriteFamiliesSection(StreamWriter writer, IList<SupportFamily> families, Link links)
 {
     ReadOnlySpan<string> labels = ["OS", "Versions", "Architectures", "Lifecycle"];
-    int[] lengths = [32, 30, 24, 24];
     int linkCount = 0;
     bool first = true;
 
@@ -165,7 +164,7 @@ static void WriteFamiliesSection(StreamWriter writer, IList<SupportFamily> famil
             writer.WriteLine();
         }
 
-        Table table = new(Writer.GetWriter(writer), lengths);
+        Table table = new(Writer.GetWriter(writer));
         Link familyLinks = new(linkCount);
         writer.WriteLine($"## {family.Name}");
         writer.WriteLine();
@@ -212,6 +211,8 @@ static void WriteFamiliesSection(StreamWriter writer, IList<SupportFamily> famil
                 }
             }
         }
+        
+        table.Render();
 
         if (notes.Count > 0)
         {
@@ -237,8 +238,7 @@ static void WriteFamiliesSection(StreamWriter writer, IList<SupportFamily> famil
 static void WriteLibcSection(StreamWriter writer, IList<SupportLibc> supportedLibc)
 {
     string[] columnLabels = ["Libc", "Version", "Architectures", "Source"];
-    int[] columnLengths = [16, 10, 24, 16];
-    Table table = new(Writer.GetWriter(writer), columnLengths);
+    Table table = new(Writer.GetWriter(writer));
     table.WriteHeader(columnLabels);
 
     foreach (SupportLibc libc in supportedLibc)
@@ -249,6 +249,8 @@ static void WriteLibcSection(StreamWriter writer, IList<SupportLibc> supportedLi
         table.WriteColumn(libc.Source);
         table.EndRow();
     }
+    
+    table.Render();
 }
 
 static void WriteNotesSection(StreamWriter writer, IList<string> notes)
@@ -279,15 +281,14 @@ static async Task WriteUnSupportedSection(StreamWriter writer, IList<SupportFami
         .ThenByDescending(entry => GetEolDateForCycle(entry.Cycle))
         .ToArray();
 
-    if (eolCycles.Length == 0)
+    if (orderedEolCycles.Length == 0)
     {
         writer.WriteLine("None currently.");
         return;
     }
 
     string[] labels = ["OS", "Version", "Date"];
-    int[] lengths = [24, 16, 24];
-    Table table = new(Writer.GetWriter(writer), lengths);
+    Table table = new(Writer.GetWriter(writer));
 
     table.WriteHeader(labels);
 
@@ -306,6 +307,8 @@ static async Task WriteUnSupportedSection(StreamWriter writer, IList<SupportFami
         table.WriteColumn(eol);
         table.EndRow();
     }
+    
+    table.Render();
 }
 
 static string GetEolTextForCycle(SupportCycle? cycle)


### PR DESCRIPTION
Prompt:

There is a markdown table generation class in this repo that operates on static/fragile data. I want to make it dynamic.
 
You can see that at @richlander/distroessed/files/src/CveMarkdown/CveReport.cs
 
Change the library so that it no longer takes column lengths (even as an option) but still generates tables with aligned columns.
 
Here are the rules:
 
- The table does not exceed a specified width. Default is .75 of 80 characters.
- Columns are smart-sized. If one row makes a column go wide, that doesn't make the whole column go wide. The default width for a column should be calculated on the width required by the shortest 50% of rows. This thresthold should be configurable. Default is 50%.
- Columns are at least as wide as the header text. This is only configurable by changing the header text.